### PR TITLE
[WIP] Custom GBSA

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
     entry_points={
         "openff.toolkit.plugins.handlers": [
             "DampedBuckingham68 = smirnoff_plugins.handlers.nonbonded:DampedBuckingham68"
+            "CustomGBSAHandler = smirnoff_plugins.handlers.customgbsa:CustomOBCHandler"
         ]
     },
 )

--- a/smirnoff_plugins/handlers/customgbsa.py
+++ b/smirnoff_plugins/handlers/customgbsa.py
@@ -1,0 +1,314 @@
+import abc
+from typing import List, Tuple
+
+import numpy
+from openff.toolkit.topology import Topology
+from openff.toolkit.typing.engines.smirnoff import (
+    ParameterAttribute,
+    ParameterHandler,
+    ParameterType,
+)
+from openff.toolkit.typing.engines.smirnoff.parameters import (
+    IncompatibleParameterError,
+    VirtualSiteHandler,
+    vdWHandler,
+    ElectrostaticsHandler,
+    ToolkitAM1BCCHandler,
+    ChargeIncrementModelHandler,
+    LibraryChargeHandler,
+    _allow_only,
+)
+from simtk import openmm, unit
+
+
+class CustomOBCHandler(ParameterHandler):
+    """Handle SMIRNOFF ``<CustomOBC>`` tags
+
+    .. warning :: This API is experimental and subject to change.
+    """
+
+    class CustomOBCType(ParameterType):
+        """A SMIRNOFF GBSA type.
+
+        .. warning :: This API is experimental and subject to change.
+        """
+
+        _VALENCE_TYPE = "Atom"
+        _ELEMENT_NAME = "Atom"
+
+        radius = ParameterAttribute(unit=unit.angstrom)
+        scale = ParameterAttribute(converter=float)
+
+    _TAGNAME = "CustomOBC"
+    _INFOTYPE = CustomOBCType
+    #_OPENMMTYPE = openmm.app.internal.customgbforces.CustomAmberGBForceBase
+    _OPENMMTYPE = openmm.CustomGBForce
+    # It's important that this runs AFTER partial charges are assigned to all particles, since this will need to
+    # collect and assign them to the GBSA particles
+    _DEPENDENCIES = [
+        vdWHandler,
+        ElectrostaticsHandler,
+        ToolkitAM1BCCHandler,
+        ChargeIncrementModelHandler,
+        LibraryChargeHandler,
+    ]
+
+    # This is where we define all the keywords that may be defined in the section header in the OFFXML
+    #gb_model = ParameterAttribute(
+    #    default="OBC1", converter=_allow_only(["HCT", "OBC1", "OBC2"])
+    #)
+    alpha = ParameterAttribute(converter=float)
+    beta = ParameterAttribute(converter=float)
+    gamma = ParameterAttribute(converter=float)
+
+    solvent_dielectric = ParameterAttribute(default=78.5, converter=float)
+    solute_dielectric = ParameterAttribute(default=1, converter=float)
+    sa_model = ParameterAttribute(default="ACE", converter=_allow_only(["ACE", None]))
+
+    # TODO: We can't find where this value is actually fed into the CustomGBForce. We should validate that
+    #       this is actually being used correctly
+    surface_area_penalty = ParameterAttribute(
+        default=5.4 * unit.calorie / unit.mole / unit.angstrom ** 2,
+        unit=unit.calorie / unit.mole / unit.angstrom ** 2,
+    )
+    solvent_radius = ParameterAttribute(default=1.4 * unit.angstrom, unit=unit.angstrom)
+
+    def _validate_parameters(self):
+        """
+        Checks internal attributes, raising an exception if they are configured in an invalid way.
+        """
+        # If we're using HCT via GBSAHCTForce(CustomAmberGBForceBase):, then we need to ensure that:
+        #   surface_area_energy is 5.4 cal/mol/A^2
+        #   solvent_radius is 1.4 A
+        # Justification at https://github.com/openforcefield/openff-toolkit/pull/363
+        #if self.gb_model == "HCT":
+        #    if (
+        #        self.surface_area_penalty
+        #        != 5.4 * unit.calorie / unit.mole / unit.angstrom ** 2
+        #    ) and (self.sa_model is not None):
+        #        raise IncompatibleParameterError(
+        #            f"The current implementation of HCT GBSA does not "
+        #            f"support surface_area_penalty values other than 5.4 "
+        #            f"cal/mol A^2 (data source specified value of "
+        #            f"{self.surface_area_penalty})"
+        #        )
+        #
+        #    if (self.solvent_radius != 1.4 * unit.angstrom) and (
+        #        self.sa_model is not None
+        #    ):
+        #        raise IncompatibleParameterError(
+        #            f"The current implementation of HCT GBSA does not "
+        #            f"support solvent_radius values other than 1.4 "
+        #            f"A (data source specified value of "
+        #            f"{self.solvent_radius})"
+        #        )
+
+        # If we're using OBC1 via GBSAOBC1Force(CustomAmberGBForceBase), then we need to ensure that:
+        #   surface_area_energy is 5.4 cal/mol/A^2
+        #   solvent_radius is 1.4 A
+        # Justification at https://github.com/openforcefield/openff-toolkit/pull/363
+        #if self.gb_model == "OBC1":
+        #    if (
+        #        self.surface_area_penalty
+        #        != 5.4 * unit.calorie / unit.mole / unit.angstrom ** 2
+        #    ) and (self.sa_model is not None):
+        #        raise IncompatibleParameterError(
+        #            f"The current implementation of OBC1 GBSA does not "
+        #            f"support surface_area_penalty values other than 5.4 "
+        #            f"cal/mol A^2 (data source specified value of "
+        #            f"{self.surface_area_penalty})"
+        #        )
+        #
+        #    if (self.solvent_radius != 1.4 * unit.angstrom) and (
+        #        self.sa_model is not None
+        #    ):
+        #        raise IncompatibleParameterError(
+        #            f"The current implementation of OBC1 GBSA does not "
+        #            f"support solvent_radius values other than 1.4 "
+        #            f"A (data source specified value of "
+        #            f"{self.solvent_radius})"
+        #        )
+
+        # If we're using OBC2 via GBSAOBCForce, then we need to ensure that
+        #   solvent_radius is 1.4 A
+        # Justification at https://github.com/openforcefield/openff-toolkit/pull/363
+        #if self.gb_model == "OBC2":
+        #
+        #    if (self.solvent_radius != 1.4 * unit.angstrom) and (
+        #        self.sa_model is not None
+        #    ):
+        #        raise IncompatibleParameterError(
+        #            f"The current implementation of OBC1 GBSA does not "
+        #            f"support solvent_radius values other than 1.4 "
+        #            f"A (data source specified value of "
+        #            f"{self.solvent_radius})"
+        #        )
+
+        if (self.solvent_radius != 1.4 * unit.angstrom) and (
+                self.sa_model is not None
+        ):
+            raise IncompatibleParameterError(
+                f"The current implementation of OBC1 GBSA does not "
+                f"support solvent_radius values other than 1.4 "
+                f"A (data source specified value of "
+                f"{self.solvent_radius})"
+            )
+
+    # Tolerance when comparing float attributes for handler compatibility.
+    _SCALETOL = 1e-5
+
+    def check_handler_compatibility(self, other_handler):
+        """
+        Checks whether this ParameterHandler encodes compatible physics as another ParameterHandler. This is
+        called if a second handler is attempted to be initialized for the same tag.
+
+        Parameters
+        ----------
+        other_handler : a ParameterHandler object
+            The handler to compare to.
+
+        Raises
+        ------
+        IncompatibleParameterError if handler_kwargs are incompatible with existing parameters.
+        """
+        float_attrs_to_compare = ["alpha", "beta", "gamma", "solvent_dielectric", "solute_dielectric"]
+        string_attrs_to_compare = ["sa_model"]
+        unit_attrs_to_compare = ["surface_area_penalty", "solvent_radius"]
+
+        self._check_attributes_are_equal(
+            other_handler,
+            identical_attrs=string_attrs_to_compare,
+            tolerance_attrs=float_attrs_to_compare + unit_attrs_to_compare,
+            tolerance=self._SCALETOL,
+        )
+
+    def create_force(self, system, topology, **kwargs):
+        import simtk
+
+        self._validate_parameters()
+
+        # Grab the existing nonbonded force (which will have particle charges)
+        existing = [system.getForce(i) for i in range(system.getNumForces())]
+        existing = [f for f in existing if type(f) == openmm.NonbondedForce]
+        assert len(existing) == 1
+
+        nonbonded_force = existing[0]
+
+        # No previous GBSAForce should exist, so we're safe just making one here.
+        #force_map = {
+        #    "HCT": simtk.openmm.app.internal.customgbforces.GBSAHCTForce,
+        #    "OBC1": simtk.openmm.app.internal.customgbforces.GBSAOBC1Force,
+        #    "OBC2": simtk.openmm.GBSAOBCForce,
+            # It's tempting to do use the class below, but the customgbforce
+            # version of OBC2 doesn't provide setSolventRadius()
+            #'OBC2': simtk.openmm.app.internal.customgbforces.GBSAOBC2Force,
+        #}
+        #openmm_force_type = force_map[self.gb_model]
+
+        if nonbonded_force.getNonbondedMethod() == openmm.NonbondedForce.NoCutoff:
+            amber_cutoff = None
+        else:
+            amber_cutoff = nonbonded_force.getCutoffDistance().value_in_unit(
+                unit.nanometer
+            )
+
+        #if self.gb_model == "OBC2":
+        gbsa_force = self._OPENMMTYPE()
+
+        #else:
+            # We set these values in the constructor if we use the internal AMBER GBSA type wrapper
+        #    gbsa_force = openmm_force_type(
+        #        solventDielectric=self.solvent_dielectric,
+        #        soluteDielectric=self.solute_dielectric,
+        #        SA=self.sa_model,
+        #        cutoff=amber_cutoff,
+        #        kappa=0,
+        #    )
+            # WARNING: If using a CustomAmberGBForce, the functional form is affected by whether
+            # the cutoff kwarg is None *during initialization*. So, if you initialize it with a
+            # non-None value, and then try to change it to None, you're likely to get unphysical results.
+
+        # Set the GBSAForce to have the same cutoff as NonbondedForce
+        # gbsa_force.setCutoffDistance(nonbonded_force.getCutoffDistance())
+        if amber_cutoff is not None:
+            gbsa_force.setCutoffDistance(amber_cutoff)
+
+        if nonbonded_force.usesPeriodicBoundaryConditions():
+            # WARNING: The lines below aren't equivalent. The NonbondedForce and
+            # CustomGBForce NonbondedMethod enums have different meanings.
+            # More details:
+            # http://docs.openmm.org/latest/api-python/generated/simtk.openmm.openmm.NonbondedForce.html
+            # http://docs.openmm.org/latest/api-python/generated/simtk.openmm.openmm.GBSAOBCForce.html
+            # http://docs.openmm.org/latest/api-python/generated/simtk.openmm.openmm.CustomGBForce.html
+
+            # gbsa_force.setNonbondedMethod(simtk.openmm.NonbondedForce.CutoffPeriodic)
+            gbsa_force.setNonbondedMethod(simtk.openmm.CustomGBForce.CutoffPeriodic)
+        else:
+            # gbsa_force.setNonbondedMethod(simtk.openmm.NonbondedForce.NoCutoff)
+            gbsa_force.setNonbondedMethod(simtk.openmm.CustomGBForce.NoCutoff)
+
+        gbsa_force.addPerParticleParameter("charge")
+        gbsa_force.addPerParticleParameter("or") # Offset radius
+        gbsa_force.addPerParticleParameter("sr") # Scaled offset radius
+        gbsa_force.addComputedValue("I",  "select(step(r+sr2-or1), 0.5*(1/L-1/U+0.25*(r-sr2^2/r)*(1/(U^2)-1/(L^2))+0.5*log(L/U)/r), 0);"
+                                    "U=r+sr2;"
+                                    "L=max(or1, D);"
+                                    "D=abs(r-sr2)", openmm.CustomGBForce.ParticlePairNoExclusions)
+
+        #b_eqn = f"1/(1/or-tanh({alpha}*psi+{gamma}*psi^3)/radius);"
+        b_eqn = f"1/(1/or-tanh({alpha}*psi-{beta}*psi^2+{gamma}*psi^3)/radius);"
+        gbsa_force.addComputedValue("B", b_eqn + "psi=I*or; radius=or+offset; offset=0.009", openmm.CustomGBForce.SingleParticle)
+
+        # Add all GBSA terms to the system. Note that this will have been done above
+        #if self.gb_model == "OBC2":
+        #    gbsa_force.setSolventDielectric(self.solvent_dielectric)
+        #    gbsa_force.setSoluteDielectric(self.solute_dielectric)
+        #    if self.sa_model is None:
+        #        gbsa_force.setSurfaceAreaEnergy(0)
+        #    else:
+        #        gbsa_force.setSurfaceAreaEnergy(self.surface_area_penalty)
+
+        # Iterate over all defined GBSA types, allowing later matches to override earlier ones.
+        atom_matches = self.find_matches(topology)
+
+        # Create all particles.
+
+        # !!! WARNING: CustomAmberGBForceBase expects different per-particle parameters
+        # depending on whether you use addParticle or setParticleParameters. In
+        # setParticleParameters, we have to apply the offset and scale BEFORE setting
+        # parameters, whereas in addParticle, the offset is applied automatically, and the particle
+        # parameters are not set until an auxillary finalize() method is called. !!!
+
+        # To keep it simple, we DO NOT pre-populate the particles in the GBSA force here.
+        # We call addParticle further below instead.
+        # These lines are commented out intentionally as an example of what NOT to do.
+        # for topology_particle in topology.topology_particles:
+        # gbsa_force.addParticle([0.0, 1.0, 0.0])
+
+        params_to_add = [[] for _ in topology.topology_particles]
+        for atom_key, atom_match in atom_matches.items():
+            atom_idx = atom_key[0]
+            gbsatype = atom_match.parameter_type
+            charge, _, _2 = nonbonded_force.getParticleParameters(atom_idx)
+            params_to_add[atom_idx] = [charge, gbsatype.radius, gbsatype.scale]
+
+        #if self.gb_model == "OBC2":
+        #    for particle_param in params_to_add:
+        #        gbsa_force.addParticle(*particle_param)
+        #else:
+        #    for particle_param in params_to_add:
+        #        gbsa_force.addParticle(particle_param)
+        #    # We have to call finalize() for models that inherit from CustomAmberGBForceBase,
+        #    # otherwise the added particles aren't actually passed to the underlying CustomGBForce
+        #    gbsa_force.finalize()
+
+        for particle_param in params_to_add:
+            gbsa_force.addParticle(*particle_param)
+
+        # Check that no atoms (n.b. not particles) are missing force parameters.
+        self._check_all_valence_terms_assigned(
+            assigned_terms=atom_matches, valence_terms=list(topology.topology_atoms)
+        )
+
+        system.addForce(gbsa_force)
+

--- a/smirnoff_plugins/tests/handlers/test_custom_obc.py
+++ b/smirnoff_plugins/tests/handlers/test_custom_obc.py
@@ -1,11 +1,17 @@
+import pytest
+import copy
 from openff.toolkit.typing.engines.smirnoff import ForceField
 from smirnoff_plugins.handlers.customgbsa import CustomOBCHandler
-
+from openff.toolkit.topology import Molecule
+from openff.toolkit.tests.test_forcefield import generate_freesolv_parameters_assignment_cases
+from openff.toolkit.tests.utils import requires_openeye_mol2
+import simtk.unit as unit
+from tempfile import NamedTemporaryFile
 
 obc1_equiv_offxml = '''<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
     <!-- This file is intended to replicate the settings and per-particle parameters provided by OpenMM's customgbforces.GBSAOBC1Force class -->
     <!-- This file should replicate the OBC1 parameter set and energies -->
-    <CustomOBC version="0.3" alpha="0.8" beta="0.0" gamma="2.909125" solvent_dielectric="78.5" solute_dielectric="1" sa_model="ACE" surface_area_penalty="5.4*calories/mole/angstroms**2" solvent_radius="1.4*angstroms">
+    <CustomOBC version="0.3" alpha="0.8" beta="0.0" gamma="2.909125" solvent_dielectric="78.5" solute_dielectric="1" sa_model="ACE" surface_area_penalty="5.4*calories/mole/angstroms**2" solvent_radius="1.4*angstroms" kappa="0.0/angstrom">
       <Atom smirks="[*:1]" radius="0.15*nanometer" scale="0.8"/>
       <Atom smirks="[#1:1]" radius="0.12*nanometer" scale="0.85"/>
       <Atom smirks="[#1:1]~[#7]" radius="0.13*nanometer" scale="0.85"/>
@@ -24,3 +30,195 @@ obc1_equiv_offxml = '''<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL
 class TestCustomOBC:
     def test_parse_xml(self):
         ff = ForceField(obc1_equiv_offxml)
+
+    @requires_openeye_mol2
+    @pytest.mark.parametrize(("is_periodic"), (False, True))
+    @pytest.mark.parametrize(
+        ("freesolv_id", "forcefield_version", "allow_undefined_stereo"),
+        generate_freesolv_parameters_assignment_cases(),
+    )
+    def test_freesolv_gbsa_energies(
+        self,
+        is_periodic,
+        freesolv_id,
+        forcefield_version,
+        allow_undefined_stereo,
+    ):
+        """
+        Regression test on HCT, OBC1, and OBC2 GBSA models. This test ensures that the
+        SMIRNOFF-based GBSA models match the equivalent OpenMM implementations.
+        """
+    
+        import parmed as pmd
+        from simtk import openmm
+        from simtk.openmm import Platform
+    
+        from openff.toolkit.tests.utils import (
+            compare_system_energies,
+            create_system_from_amber,
+            get_context_potential_energy,
+            get_freesolv_file_path,
+        )
+    
+        mol2_file_path, _ = get_freesolv_file_path(freesolv_id, forcefield_version)
+    
+        # Load molecules.
+        molecule = Molecule.from_file(
+            mol2_file_path, allow_undefined_stereo=allow_undefined_stereo
+        )
+    
+        # Give each atom a unique name, otherwise OpenMM will complain
+        for idx, atom in enumerate(molecule.atoms):
+            atom.name = f"{atom.element.symbol}{idx}"
+        positions = molecule.conformers[0]
+    
+        # Create OpenFF System with the current toolkit.
+        ff = ForceField(
+            "test_forcefields/test_forcefield.offxml", obc1_equiv_offxml
+        )
+        off_top = molecule.to_topology()
+        if is_periodic:
+            off_top.box_vectors = (
+                (30.0, 0, 0),
+                (0, 30.0, 0),
+                (0, 0, 30.0),
+            ) * unit.angstrom
+    
+        else:
+            off_top.box_vectors = None
+    
+        off_omm_system = ff.create_openmm_system(
+            off_top, charge_from_molecules=[molecule]
+        )
+    
+        off_nonbonded_force = [
+            force
+            for force in off_omm_system.getForces()
+            if isinstance(force, openmm.NonbondedForce)
+        ][0]
+    
+        omm_top = off_top.to_openmm()
+        pmd_struct = pmd.openmm.load_topology(omm_top, off_omm_system, positions)
+        prmtop_file = NamedTemporaryFile(suffix=".prmtop")
+        inpcrd_file = NamedTemporaryFile(suffix=".inpcrd")
+        pmd_struct.save(prmtop_file.name, overwrite=True)
+        pmd_struct.save(inpcrd_file.name, overwrite=True)
+    
+        # The functional form of the nonbonded force will change depending on whether the cutoff
+        # is None during initialization. Therefore, we need to figure that out here.
+    
+        # WARNING: The NonbondedMethod enums at openmm.app.forcefield and openmm.CustomGBForce
+        # aren't necessarily the same, and could be misinterpreted if the wrong one is used. For
+        # create_system_from_amber, we must provide the app.forcefield version.
+    
+        if is_periodic:
+            amber_nb_method = openmm.app.forcefield.CutoffPeriodic
+            amber_cutoff = off_nonbonded_force.getCutoffDistance()
+        else:
+            amber_nb_method = openmm.app.forcefield.NoCutoff
+            amber_cutoff = None
+    
+        (
+            amber_omm_system,
+            amber_omm_topology,
+            amber_positions,
+        ) = create_system_from_amber(
+            prmtop_file.name,
+            inpcrd_file.name,
+            implicitSolvent=openmm.app.OBC1,
+            nonbondedMethod=amber_nb_method,
+            nonbondedCutoff=amber_cutoff,
+            gbsaModel="ACE",
+            implicitSolventKappa=0.0,
+        )
+    
+        # Retrieve the GBSAForce from both the AMBER and OpenForceField systems
+        off_gbsa_forces = [
+            force
+            for force in off_omm_system.getForces()
+            if (
+                isinstance(force, openmm.GBSAOBCForce)
+                or isinstance(force, openmm.openmm.CustomGBForce)
+            )
+        ]
+        assert len(off_gbsa_forces) == 1
+        off_gbsa_force = off_gbsa_forces[0]
+        amber_gbsa_forces = [
+            force
+            for force in amber_omm_system.getForces()
+            if (
+                isinstance(force, openmm.GBSAOBCForce)
+                or isinstance(force, openmm.openmm.CustomGBForce)
+            )
+        ]
+        assert len(amber_gbsa_forces) == 1
+        amber_gbsa_force = amber_gbsa_forces[0]
+    
+        # We get radius and screen values from each model's getStandardParameters method
+        gb_params = (
+            openmm.app.internal.customgbforces.GBSAOBC1Force.getStandardParameters(
+                omm_top
+            )
+        )
+    
+        # Use GB params from OpenMM GBSA classes to populate parameters
+        for idx, (radius, screen) in enumerate(gb_params):
+            # Keep the charge, but throw out the old radius and screen values
+            q, old_radius, old_screen = amber_gbsa_force.getParticleParameters(idx)
+            if isinstance(amber_gbsa_force, openmm.GBSAOBCForce):
+                # Note that in GBSAOBCForce, the per-particle parameters are separate
+                # arguments, while in CustomGBForce they're a single iterable
+                amber_gbsa_force.setParticleParameters(idx, q, radius, screen)
+    
+            elif isinstance(amber_gbsa_force, openmm.CustomGBForce):
+                # !!! WARNING: CustomAmberGBForceBase expects different per-particle parameters
+                # depending on whether you use addParticle or setParticleParameters. In
+                # setParticleParameters, we have to apply the offset and scale BEFORE setting
+                # parameters, whereas in addParticle, it is applied afterwards, and the particle
+                # parameters are not set until an auxillary finalize() method is called. !!!
+                amber_gbsa_force.setParticleParameters(
+                    idx, (q, radius - 0.009, screen * (radius - 0.009))
+                )
+    
+        # Put the GBSA force into a separate group so we can specifically compare GBSA energies
+        amber_gbsa_force.setForceGroup(1)
+        off_gbsa_force.setForceGroup(1)
+    
+        # Some manual overrides to get the OFF system's NonbondedForce matched up with the AMBER system
+        if is_periodic:
+            off_nonbonded_force.setNonbondedMethod(openmm.NonbondedForce.CutoffPeriodic)
+        else:
+            off_nonbonded_force.setNonbondedMethod(openmm.NonbondedForce.NoCutoff)
+    
+        off_nonbonded_force.setReactionFieldDielectric(1.0)
+    
+        # Not sure if zeroing the switching width is essential -- This might only make a difference
+        # in the energy if we tested on a molecule larger than the 9A cutoff
+        # off_nonbonded_force.setSwitchingDistance(0)
+    
+        # Create Contexts
+        integrator = openmm.VerletIntegrator(1.0 * unit.femtoseconds)
+        platform = Platform.getPlatformByName("Reference")
+        amber_context = openmm.Context(amber_omm_system, integrator, platform)
+        off_context = openmm.Context(
+            off_omm_system, copy.deepcopy(integrator), platform
+        )
+    
+        # Get context energies
+        amber_energy = get_context_potential_energy(amber_context, positions)
+        off_energy = get_context_potential_energy(off_context, positions)
+    
+        # Very handy for debugging
+        # print(openmm.XmlSerializer.serialize(off_gbsa_force))
+        # print(openmm.XmlSerializer.serialize(amber_gbsa_force))
+    
+        # Ensure that the GBSA energies (which we put into ForceGroup 1) are identical
+        # For Platform=OpenCL, we do get "=="-level identical numbers, but for "Reference", we don't.
+        # assert amber_energy[1] == off_energy[1]
+        assert abs(amber_energy[1] - off_energy[1]) < 1e-5 * unit.kilojoule / unit.mole
+    
+        # Ensure that all system energies are the same
+        compare_system_energies(
+            off_omm_system, amber_omm_system, positions, by_force_type=False
+        )
+

--- a/smirnoff_plugins/tests/handlers/test_custom_obc.py
+++ b/smirnoff_plugins/tests/handlers/test_custom_obc.py
@@ -1,0 +1,26 @@
+from openff.toolkit.typing.engines.smirnoff import ForceField
+from smirnoff_plugins.handlers.customgbsa import CustomOBCHandler
+
+
+obc1_equiv_offxml = '''<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
+    <!-- This file is intended to replicate the settings and per-particle parameters provided by OpenMM's customgbforces.GBSAOBC1Force class -->
+    <!-- This file should replicate the OBC1 parameter set and energies -->
+    <CustomOBC version="0.3" alpha="0.8" beta="0.0" gamma="2.909125" solvent_dielectric="78.5" solute_dielectric="1" sa_model="ACE" surface_area_penalty="5.4*calories/mole/angstroms**2" solvent_radius="1.4*angstroms">
+      <Atom smirks="[*:1]" radius="0.15*nanometer" scale="0.8"/>
+      <Atom smirks="[#1:1]" radius="0.12*nanometer" scale="0.85"/>
+      <Atom smirks="[#1:1]~[#7]" radius="0.13*nanometer" scale="0.85"/>
+      <Atom smirks="[#6:1]" radius="0.17*nanometer" scale="0.72"/>
+      <Atom smirks="[#7:1]" radius="0.155*nanometer" scale="0.79"/>
+      <Atom smirks="[#8:1]" radius="0.15*nanometer" scale="0.85"/>
+      <Atom smirks="[#9:1]" radius="0.15*nanometer" scale="0.88"/>
+      <Atom smirks="[#14:1]" radius="0.21*nanometer" scale="0.8"/>
+      <Atom smirks="[#15:1]" radius="0.185*nanometer" scale="0.86"/>
+      <Atom smirks="[#16:1]" radius="0.18*nanometer" scale="0.96"/>
+      <Atom smirks="[#17:1]" radius="0.17*nanometer" scale="0.8"/>
+    </CustomOBC>
+</SMIRNOFF>
+'''
+
+class TestCustomOBC:
+    def test_parse_xml(self):
+        ff = ForceField(obc1_equiv_offxml)


### PR DESCRIPTION
## Description
Adding GBSAHandler(s) that allow varying the `alpha`, `beta`, `gamma`, and possibly `kappa` globals in OBC models. Possibly also adding support for the GBn1+2 models.

## Todos
- [ ] Get OBC1 reference energy tests matching
    - [ ] Document whether the `radius` particle parameter SHOULD or SHOULD NOT have the offset (`0.009 nm`) applied in each method
- [ ] Get OBC2 reference energy tests matching
- [ ] Get some test with nonzero kappa matching known references (?)
- [ ] IF we allow changing the surface_area_penalty, add tests matching to a known model with a different SA term.

## Questions
- Should we allow people to change the offset (`0.009 nm`)?
    - @jeff231li: No

## Status
- [ ] Ready to go