### PR TITLE
Use custom bond force for 1-4 interactions

### DIFF
--- a/smirnoff_plugins/handlers/nonbonded.py
+++ b/smirnoff_plugins/handlers/nonbonded.py
@@ -73,8 +73,7 @@ class CustomNonbondedHandler(ParameterHandler, abc.ABC):
         for i, expression in enumerate(potential):
             if "=" not in expression:
                 # This is the final energy so modify
-                if "(" not in expression and ")" not in expression:
-                    expression = "(" + expression + ")"
+                expression = "(" + expression + ")"
                 expression += "*scale14"
                 potential[i] = expression
                 break
@@ -255,7 +254,7 @@ class CustomNonbondedHandler(ParameterHandler, abc.ABC):
             force.addExclusion(*missing_exclusion)
 
         # Add 1-4 scaled interactions only if the scale is not 1
-        if self.scale14 != 1:
+        if not numpy.isclose(self.scale14, 1.0):
             # build a custom bond force to hold the 1-4s
             scaled_force = openmm.CustomBondForce(self._get_scaled_potential_function())
 

--- a/smirnoff_plugins/tests/conftest.py
+++ b/smirnoff_plugins/tests/conftest.py
@@ -139,7 +139,6 @@ def ideal_water_force_field() -> ForceField:
             "sigma": 0.0 * unit.nanometers,
         }
     )
-    ff.get_parameter_handler("Electrostatics")
     # add the library charges
     library_charge = ff.get_parameter_handler("LibraryCharges")
     library_charge.add_parameter(

--- a/smirnoff_plugins/tests/handlers/test_nonbonded.py
+++ b/smirnoff_plugins/tests/handlers/test_nonbonded.py
@@ -88,7 +88,6 @@ def test_double_exp_energies(ideal_water_force_field):
     )
     # calculated by hand (kJ / mol), at r_min the energy should be epsilon
     ref_values = [457.0334854, -0.635968, -0.4893932627]
-    print(energies)
     for i, energy in enumerate(energies):
         assert energy == pytest.approx(ref_values[i])
 

--- a/smirnoff_plugins/tests/handlers/test_nonbonded.py
+++ b/smirnoff_plugins/tests/handlers/test_nonbonded.py
@@ -180,16 +180,6 @@ def test_scaled_de_energy():
     off_top = ethane.to_topology()
     omm_top = off_top.to_openmm()
     system_no_scale = ff.create_openmm_system(topology=off_top)
-    existing_forces = [
-        system_no_scale.getForce(i)
-        for i in range(system_no_scale.getNumForces())
-        if isinstance(system_no_scale.getForce(i), openmm.NonbondedForce)
-    ]
-    existing_exclusions = set(
-        tuple(sorted(existing_force.getExceptionParameters(i)[0:2]))
-        for existing_force in existing_forces
-        for i in range(existing_force.getNumExceptions())
-    )
     energy_no_scale = evaluate_energy(
         system=system_no_scale, topology=omm_top, positions=ethane.conformers[0]
     )

--- a/smirnoff_plugins/utilities/openmm.py
+++ b/smirnoff_plugins/utilities/openmm.py
@@ -273,8 +273,6 @@ def evaluate_water_energy_at_distances(
         * unit.angstrom
         for x in distances
     ]
-    with open("system.xml", "w") as f:
-        f.write(openmm.XmlSerializer.serialize(omm_system))
     # Add the virtual sites to the OpenMM topology and positions.
     omm_topology = topology.to_openmm()
     omm_chain = [*omm_topology.chains()][-1]


### PR DESCRIPTION
## Description
This PR adds support for scaled 1-4 interactions with custom nonbonded forces. These interactions are implemented via a custom bond force between the two particles.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Status
- [ ] Ready to go