### PR TITLE
Fix CI

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -8,7 +8,7 @@ dependencies:
   - pip
 
     # Core dependencies
-  - openff-toolkit =0.10.4
+  - openff-toolkit >=0.10.6,<0.11.0
   - packaging  # Missing OFF TK dependency.
   - openmm
 

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -8,7 +8,7 @@ dependencies:
   - pip
 
     # Core dependencies
-  - openff-toolkit
+  - openff-toolkit =0.10.4
   - packaging  # Missing OFF TK dependency.
   - openmm
 

--- a/smirnoff_plugins/handlers/nonbonded.py
+++ b/smirnoff_plugins/handlers/nonbonded.py
@@ -301,7 +301,7 @@ class CustomNonbondedHandler(ParameterHandler, abc.ABC):
 class DampedBuckingham68(CustomNonbondedHandler):
     """The B68 potential."""
 
-    gamma = ParameterAttribute(default=35.8967, unit=unit.nanometer ** -1)
+    gamma = ParameterAttribute(default=35.8967, unit=unit.nanometer**-1)
 
     class B68Type(ParameterType):
 
@@ -309,19 +309,19 @@ class DampedBuckingham68(CustomNonbondedHandler):
         _ELEMENT_NAME = "Atom"
 
         a = ParameterAttribute(default=None, unit=unit.kilojoule_per_mole)
-        b = ParameterAttribute(default=None, unit=unit.nanometer ** -1)
+        b = ParameterAttribute(default=None, unit=unit.nanometer**-1)
         c6 = ParameterAttribute(
-            default=None, unit=unit.kilojoule_per_mole * unit.nanometer ** 6
+            default=None, unit=unit.kilojoule_per_mole * unit.nanometer**6
         )
         c8 = ParameterAttribute(
-            default=None, unit=unit.kilojoule_per_mole * unit.nanometer ** 8
+            default=None, unit=unit.kilojoule_per_mole * unit.nanometer**8
         )
 
     _TAGNAME = "DampedBuckingham68"  # SMIRNOFF tag name to process
     _INFOTYPE = B68Type  # info type to store
 
     def _pre_computed_terms(self) -> Dict[str, float]:
-        d2 = self.gamma ** 2 * 0.5
+        d2 = self.gamma**2 * 0.5
         d3 = d2 * self.gamma * 0.3333333333
         d4 = d3 * self.gamma * 0.25
         d5 = d4 * self.gamma * 0.2
@@ -372,15 +372,15 @@ class DampedBuckingham68(CustomNonbondedHandler):
 
         return (
             numpy.sqrt(parameter_type.a.value_in_unit(unit.kilojoule_per_mole)),
-            numpy.sqrt(parameter_type.b.value_in_unit(unit.nanometer ** -1)),
+            numpy.sqrt(parameter_type.b.value_in_unit(unit.nanometer**-1)),
             numpy.sqrt(
                 parameter_type.c6.value_in_unit(
-                    unit.kilojoule_per_mole * unit.nanometer ** 6
+                    unit.kilojoule_per_mole * unit.nanometer**6
                 )
             ),
             numpy.sqrt(
                 parameter_type.c8.value_in_unit(
-                    unit.kilojoule_per_mole * unit.nanometer ** 8
+                    unit.kilojoule_per_mole * unit.nanometer**8
                 )
             ),
         )

--- a/smirnoff_plugins/tests/conftest.py
+++ b/smirnoff_plugins/tests/conftest.py
@@ -75,8 +75,8 @@ def buckingham_water_force_field() -> ForceField:
             "smirks": "[#1:1]-[#8X2H2+0]-[#1]",
             "a": 0.0 * unit.kilojoule_per_mole,
             "b": 0.0 / unit.nanometer,
-            "c6": 0.0 * unit.kilojoule_per_mole * unit.nanometer ** 6,
-            "c8": 0.0 * unit.kilojoule_per_mole * unit.nanometer ** 8,
+            "c6": 0.0 * unit.kilojoule_per_mole * unit.nanometer**6,
+            "c8": 0.0 * unit.kilojoule_per_mole * unit.nanometer**8,
         }
     )
     buckingham_handler.add_parameter(
@@ -84,8 +84,8 @@ def buckingham_water_force_field() -> ForceField:
             "smirks": "[#1]-[#8X2H2+0:1]-[#1]",
             "a": 1600000.0 * unit.kilojoule_per_mole,
             "b": 42.00 / unit.nanometer,
-            "c6": 0.003 * unit.kilojoule_per_mole * unit.nanometer ** 6,
-            "c8": 0.00003 * unit.kilojoule_per_mole * unit.nanometer ** 8,
+            "c6": 0.003 * unit.kilojoule_per_mole * unit.nanometer**6,
+            "c8": 0.00003 * unit.kilojoule_per_mole * unit.nanometer**8,
         }
     )
     return force_field

--- a/smirnoff_plugins/tests/conftest.py
+++ b/smirnoff_plugins/tests/conftest.py
@@ -56,7 +56,7 @@ def buckingham_water_force_field() -> ForceField:
     virtual_site_handler = force_field.get_parameter_handler("VirtualSites")
     virtual_site_handler.add_parameter(
         {
-            "smirks": "[#1:1]-[#8X2H2+0:2]-[#1:3]",
+            "smirks": "[#1:2]-[#8X2H2+0:1]-[#1:3]",
             "type": "DivalentLonePair",
             "distance": -0.0106 * unit.nanometers,
             "outOfPlaneAngle": 0.0 * unit.degrees,

--- a/smirnoff_plugins/tests/handlers/test_nonbonded.py
+++ b/smirnoff_plugins/tests/handlers/test_nonbonded.py
@@ -106,14 +106,14 @@ def test_b68_energies(ideal_water_force_field):
     buckingham_handler = ideal_water_force_field.get_parameter_handler(
         "DampedBuckingham68"
     )
-    buckingham_handler.gamma = gamma * unit.nanometer ** -1
+    buckingham_handler.gamma = gamma * unit.nanometer**-1
     buckingham_handler.add_parameter(
         {
             "smirks": "[#1:1]-[#8X2H2+0]-[#1]",
             "a": 0.0 * unit.kilojoule_per_mole,
             "b": 0.0 / unit.nanometer,
-            "c6": 0.0 * unit.kilojoule_per_mole * unit.nanometer ** 6,
-            "c8": 0.0 * unit.kilojoule_per_mole * unit.nanometer ** 8,
+            "c6": 0.0 * unit.kilojoule_per_mole * unit.nanometer**6,
+            "c8": 0.0 * unit.kilojoule_per_mole * unit.nanometer**8,
         }
     )
     buckingham_handler.add_parameter(
@@ -121,8 +121,8 @@ def test_b68_energies(ideal_water_force_field):
             "smirks": "[#1]-[#8X2H2+0:1]-[#1]",
             "a": a * unit.kilojoule_per_mole,
             "b": b / unit.nanometer,
-            "c6": c6 * unit.kilojoule_per_mole * unit.nanometer ** 6,
-            "c8": c8 * unit.kilojoule_per_mole * unit.nanometer ** 8,
+            "c6": c6 * unit.kilojoule_per_mole * unit.nanometer**6,
+            "c8": c8 * unit.kilojoule_per_mole * unit.nanometer**8,
         }
     )
 


### PR DESCRIPTION
This PR fixes CI jobs by linting the codebase with a more recent version of `black` and pins to the latest compatible release of the toolkit.