### PR TITLE
Add missing vsite exclusions

### DIFF
--- a/smirnoff_plugins/handlers/nonbonded.py
+++ b/smirnoff_plugins/handlers/nonbonded.py
@@ -282,8 +282,6 @@ class CustomNonbondedHandler(ParameterHandler, abc.ABC):
                 top_index_1 += top_mol_particle_start_index
                 top_index_2 += top_mol_particle_start_index
 
-                bonds.append([top_index_1, top_index_2])
-
                 # Add a 'bond' between each v-site and every atom that the 'parent' of
                 # the v-site is bonded to so that correct 'parent' policy exceptions are
                 # generated. See https://github.com/openmm/openmm/issues/2045

--- a/smirnoff_plugins/tests/conftest.py
+++ b/smirnoff_plugins/tests/conftest.py
@@ -8,6 +8,11 @@ from simtk import unit
 
 
 @pytest.fixture()
+def water() -> Molecule:
+    return Molecule.from_smiles("O")
+
+
+@pytest.fixture()
 def buckingham_water_force_field() -> ForceField:
     """Create a buckingham water model Forcefield object."""
 

--- a/smirnoff_plugins/tests/handlers/test_nonbonded.py
+++ b/smirnoff_plugins/tests/handlers/test_nonbonded.py
@@ -9,10 +9,10 @@ from smirnoff_plugins.utilities.openmm import (
 )
 
 
-def test_vsite_exclusions(buckingham_water_force_field, water):
+def test_vsite_exclusions(buckingham_water_force_field, water_box_topology):
     """Make sure the exclusions/exceptions for vsites match in the Nonbonded and Custom Nonbonded force"""
 
-    system = buckingham_water_force_field.create_openmm_system(water.to_topology())
+    system = buckingham_water_force_field.create_openmm_system(water_box_topology)
     # check we have the same number of exclusions and exceptions
     nonbonded_force = [
         force

--- a/smirnoff_plugins/tests/handlers/test_nonbonded.py
+++ b/smirnoff_plugins/tests/handlers/test_nonbonded.py
@@ -9,6 +9,24 @@ from smirnoff_plugins.utilities.openmm import (
 )
 
 
+def test_vsite_exclusions(buckingham_water_force_field, water):
+    """Make sure the exclusions/exceptions for vsites match in the Nonbonded and Custom Nonbonded force"""
+
+    system = buckingham_water_force_field.create_openmm_system(water.to_topology())
+    # check we have the same number of exclusions and exceptions
+    nonbonded_force = [
+        force
+        for force in system.getForces()
+        if isinstance(force, openmm.NonbondedForce)
+    ][0]
+    custom_force = [
+        force
+        for force in system.getForces()
+        if isinstance(force, openmm.CustomNonbondedForce)
+    ][0]
+    assert nonbonded_force.getNumExceptions() == custom_force.getNumExclusions()
+
+
 @pytest.mark.parametrize(
     "switch_width, use_switch",
     [


### PR DESCRIPTION
## Description
Fixes #40 by adding missing bonds between v-sites and parent atom neighbours to the topology before calling `createExclusionsFromBonds` on the custom force. Exclusions between sites on the same atom are also added.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [X] add tests
  - [ ] pin toolkit version in new release

## Questions
- [ ] Question1

## Status
- [ ] Ready to go