### PR TITLE
Use released version of Interchange

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -1,7 +1,6 @@
 name: smirnoff-plugins-test
 channels:
   - conda-forge
-  - conda-forge/label/openff-interchange_rc
 
 dependencies:
     # Base depends
@@ -12,7 +11,7 @@ dependencies:
   - numpy
   - openmm
   - openff-toolkit >=0.12.1
-  - openff-interchange >=0.3.0beta2
+  - openff-interchange >=0.3.0
   - openff-utilities
   - openff-models
 


### PR DESCRIPTION
## Description
I don't recall what other stop-gaps were put in place after the last big merge.

I took a skim through the source code and didn't find anything labeled loudly enough for me to notice it as needing a fix now. I also didn't get any warnings when running tests locally.

## Todos
- [x] Use a released version of Interchange

## Questions
- [ ] Have I missed anything?

## Status
- [x] Ready to go