### PR TITLE
Run `mypy` in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,6 +62,11 @@ jobs:
       run: |
         python examples/buckingham-water.py
 
+    - name: Run mypy
+      continue-on-error: true
+      run: |
+        mypy smirnoff_plugins/
+
     - name: CodeCov
       uses: codecov/codecov-action@v3
       with:

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -1,7 +1,6 @@
 name: smirnoff-plugins-test
 channels:
   - conda-forge
-  - conda-forge/label/openff-interchange_rc
 
 dependencies:
     # Base depends
@@ -12,7 +11,7 @@ dependencies:
   - numpy
   - openmm
   - openff-toolkit >=0.12.1
-  - openff-interchange >=0.3.0beta2
+  - openff-interchange >=0.3.0
   - openff-utilities
   - openff-models
 

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -19,3 +19,5 @@ dependencies:
   - pytest
   - pytest-cov
   - codecov
+
+  - mypy =1.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,3 +43,34 @@ tag_prefix = ''
 
 [aliases]
 test = pytest
+
+[mypy]
+plugins = numpy.typing.mypy_plugin
+warn_unused_configs = True
+warn_unused_ignores = True
+warn_incomplete_stub = True
+show_error_codes = True
+# https://github.com/pydantic/pydantic/issues/5192
+disable_error_code = call-arg
+
+
+[mypy-openff.toolkit.*]
+ignore_missing_imports = True
+
+[mypy-openff.units]
+ignore_missing_imports = True
+
+[mypy-openff.units.openmm]
+ignore_missing_imports = True
+
+[mypy-openmm]
+ignore_missing_imports = True
+
+[mypy-openmm.app]
+ignore_missing_imports = True
+
+[mypy-openmm.app.element]
+ignore_missing_imports = True
+
+[mypy-openmm.unit]
+ignore_missing_imports = True

--- a/smirnoff_plugins/_version.py
+++ b/smirnoff_plugins/_version.py
@@ -8,12 +8,12 @@
 # versioneer-0.19 (https://github.com/python-versioneer/python-versioneer)
 
 """Git implementation of _version.py."""
-
 import errno
 import os
 import re
 import subprocess
 import sys
+from typing import Dict
 
 
 def get_keywords():
@@ -51,7 +51,7 @@ class NotThisMethod(Exception):
     """Exception raised if a method is not valid for the current scenario."""
 
 
-LONG_VERSION_PY = {}
+LONG_VERSION_PY: Dict = {}
 HANDLERS = {}
 
 

--- a/smirnoff_plugins/collections/nonbonded.py
+++ b/smirnoff_plugins/collections/nonbonded.py
@@ -44,7 +44,7 @@ class _NonbondedPlugin(_SMIRNOFFNonbondedCollection):
     store_potentials = SMIRNOFFvdWCollection.store_potentials
 
     @classmethod
-    def create(  # type: ignore[override]
+    def create(
         cls: Type[T],
         parameter_handler: ParameterHandler,
         topology: Topology,
@@ -72,7 +72,7 @@ class _NonbondedPlugin(_SMIRNOFFNonbondedCollection):
         handler = cls(**_args)
 
         handler.store_matches(parameter_handler=parameter_handler, topology=topology)
-        handler.store_potentials(parameter_handler=parameter_handler)
+        handler.store_potentials(parameter_handler=parameter_handler)  # type: ignore[misc]
 
         return handler
 


### PR DESCRIPTION
## Description
This PR sets up `mpy` as a type-checker for checking type annotations. The codebase already used annotations in most places, so it was mostly setting up the configuration. This involves ignoring a lot of libraries - we can add stubs if we want, but I chose not to do that here - so only so much of the code is really checked. This should still provide some safeguards against weird things and hopefully few false positives.

This is based off of #54 since that's what I was working on when I noticed this.

## Todos
  - [x] Set up `mypy`
  - [x] Run `mypy` in CI

## Questions
- [ ] Question1

## Status
- [ ] Ready to go