### PR TITLE
Re-combine electrostatics terms in some plugins

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -19,6 +19,6 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
-  - pytext-randomly
+  - pytest-randomly
 
   - mypy =1.2

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -19,5 +19,6 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
+  - pytext-randomly
 
   - mypy =1.2

--- a/smirnoff_plugins/_tests/handlers/test_nonbonded.py
+++ b/smirnoff_plugins/_tests/handlers/test_nonbonded.py
@@ -547,7 +547,9 @@ def test_axilrodteller_energies():
 
     distances = [3.0, 3.5, 4.0, 4.5, 5.0, 5.5, 6.0, 7.0]
 
-    energies = [0.1 * 11 / 8 * (r / 10) ** (-9) for r in distances] * unit.kilojoule_per_mole
+    energies = [
+        0.1 * 11 / 8 * (r / 10) ** (-9) for r in distances
+    ] * unit.kilojoule_per_mole
 
     for energy, distance in zip(energies, distances):
         omm_context.setPositions(

--- a/smirnoff_plugins/collections/nonbonded.py
+++ b/smirnoff_plugins/collections/nonbonded.py
@@ -232,6 +232,7 @@ class SMIRNOFFDampedBuckingham68Collection(_NonbondedPlugin):
     ):
         self._recombine_electrostatics_1_4(system)
 
+
 class SMIRNOFFDoubleExponentialCollection(_NonbondedPlugin):
     """Handler storing vdW potentials as produced by a SMIRNOFF force field."""
 

--- a/smirnoff_plugins/collections/nonbonded.py
+++ b/smirnoff_plugins/collections/nonbonded.py
@@ -222,6 +222,15 @@ class SMIRNOFFDampedBuckingham68Collection(_NonbondedPlugin):
             for name in self.potential_parameters()
         }
 
+    def modify_openmm_forces(
+        self,
+        interchange: Interchange,
+        system: openmm.System,
+        add_constrained_forces: bool,
+        constrained_pairs: Set[Tuple[int, ...]],
+        particle_map: Dict[Union[int, "VirtualSiteKey"], int],
+    ):
+        self._recombine_electrostatics_1_4(system)
 
 class SMIRNOFFDoubleExponentialCollection(_NonbondedPlugin):
     """Handler storing vdW potentials as produced by a SMIRNOFF force field."""
@@ -390,16 +399,6 @@ class SMIRNOFFDampedExp6810Collection(_NonbondedPlugin):
             "c8": original_parameters["c8"].m_as(_units["c8"]),
             "c10": original_parameters["c10"].m_as(_units["c10"]),
         }
-
-    def modify_openmm_forces(
-        self,
-        interchange: Interchange,
-        system: openmm.System,
-        add_constrained_forces: bool,
-        constrained_pairs: Set[Tuple[int, ...]],
-        particle_map: Dict[Union[int, "VirtualSiteKey"], int],
-    ):
-        self._recombine_electrostatics_1_4(system)
 
 
 class SMIRNOFFAxilrodTellerCollection(SMIRNOFFCollection):

--- a/smirnoff_plugins/collections/nonbonded.py
+++ b/smirnoff_plugins/collections/nonbonded.py
@@ -104,7 +104,9 @@ class _NonbondedPlugin(_SMIRNOFFNonbondedCollection):
         """
         import re
 
-        for force_index, force in enumerate(system.getForces()):
+        for force_index in range(system.getNumForces()):
+            force = system.getForce(force_index)
+
             if isinstance(force, openmm.CustomBondForce):
                 if bool(
                     re.match(

--- a/smirnoff_plugins/collections/nonbonded.py
+++ b/smirnoff_plugins/collections/nonbonded.py
@@ -102,20 +102,10 @@ class _NonbondedPlugin(_SMIRNOFFNonbondedCollection):
             The system to modify.
         See for context: https://github.com/openforcefield/openff-interchange/issues/863
         """
-        import re
 
-        for force_index in range(system.getNumForces()):
-            force = system.getForce(force_index)
-
-            if isinstance(force, openmm.CustomBondForce):
-                if bool(
-                    re.match(
-                        "138.*qq/r",
-                        force.getEnergyFunction(),
-                    )
-                ):
-                    electrostatics_14_force_index = force_index
-                    continue
+        for force_index, force in enumerate(system.getForces()):
+            if force.getName() == "Electrostatics 1-4 force":
+                electrostatics_14_force_index = force_index
 
             elif isinstance(force, openmm.NonbondedForce):
                 electrostatics_force = force

--- a/smirnoff_plugins/collections/nonbonded.py
+++ b/smirnoff_plugins/collections/nonbonded.py
@@ -120,7 +120,7 @@ class _NonbondedPlugin(_SMIRNOFFNonbondedCollection):
             elif isinstance(force, openmm.NonbondedForce):
                 electrostatics_force = force
 
-        for exception_index in electrostatics_force.getNumExceptions():
+        for exception_index in range(electrostatics_force.getNumExceptions()):
             particle1, particle2, *_ = electrostatics_force.getExceptionParameters(
                 exception_index
             )
@@ -133,6 +133,8 @@ class _NonbondedPlugin(_SMIRNOFFNonbondedCollection):
                 particle1,
                 particle2,
                 charge1 * charge2 * self.scale_14,
+                0.0,
+                0.0,
             )
 
         system.removeForce(electrostatics_14_force_index)


### PR DESCRIPTION
## Description
In https://github.com/openforcefield/openff-interchange/issues/863 it was suggested that the 1-4 interactions need not be split out; this is a little method that adds the 1-4 interactions back into the canonical `NonbondedForce` and deletes the `CustomBondForce` that holds them. This doesn't really need to be a method of a plugin class - all it needs is an `openmm.System` object and the relevant 1-4 scaling factor - so it could live elsewhere.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] Add tests

## Questions
- [ ] Question1

## Status
- [ ] Ready to go