### PR TITLE
VirtualSite plugins

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
             "DampedExp6810Handler = smirnoff_plugins.handlers.nonbonded:DampedExp6810Handler",
             "AxilrodTellerHandler = smirnoff_plugins.handlers.nonbonded:AxilrodTellerHandler",
             "MultipoleHandler = smirnoff_plugins.handlers.nonbonded:MultipoleHandler",
+            "DoubleExponentialVirtualSiteHandler = smirnoff_plugins.handlers.vsites.:DoubleExponentialVirtualSiteHandler",
         ],
         "openff.interchange.plugins.collections": [
             "SMIRNOFFDampedBuckingham68Collection = smirnoff_plugins.collections.nonbonded:SMIRNOFFDampedBuckingham68Collection",
@@ -50,6 +51,7 @@ setup(
             "SMIRNOFFDampedExp6810Collection = smirnoff_plugins.collections.nonbonded:SMIRNOFFDampedExp6810Collection",
             "SMIRNOFFAxilrodTellerCollection = smirnoff_plugins.collections.nonbonded:SMIRNOFFAxilrodTellerCollection",
             "SMIRNOFFMultipoleCollection = smirnoff_plugins.collections.nonbonded:SMIRNOFFMultipoleCollection",
+            "SMIRNOFFDoubleExponentialVirtualSiteCollection = smirnoff_plugins.collections.vsites:SMIRNOFFDoubleExponentialVirtualSiteCollection",
         ],
     },
 )

--- a/smirnoff_plugins/_tests/handlers/test_nonbonded.py
+++ b/smirnoff_plugins/_tests/handlers/test_nonbonded.py
@@ -429,7 +429,8 @@ def test_14_recombining_energies_match(monkeypatch):
 
     de = ForceField(
         get_data_file_path("_tests/data/de-force-1.0.1.offxml", "smirnoff_plugins"),
-        load_plugins=True)
+        load_plugins=True,
+    )
 
     combined_energies = get_openmm_energies(
         interchange=de.create_interchange(ligand.to_topology()),

--- a/smirnoff_plugins/collections/nonbonded.py
+++ b/smirnoff_plugins/collections/nonbonded.py
@@ -363,10 +363,10 @@ class SMIRNOFFDampedExp6810Collection(_NonbondedPlugin):
         "rho = 0.5*(rho1+rho2);"
     )
 
-    force_at_zero: FloatQuantity[
-        "kilojoules_per_mole * nanometer**-1"  # noqa
-    ] = unit.Quantity(
-        49.6144931952, unit.kilojoules_per_mole * unit.nanometer**-1  # noqa
+    force_at_zero: FloatQuantity["kilojoules_per_mole * nanometer**-1"] = (  # noqa
+        unit.Quantity(
+            49.6144931952, unit.kilojoules_per_mole * unit.nanometer**-1  # noqa
+        )
     )
 
     @classmethod

--- a/smirnoff_plugins/collections/vsites.py
+++ b/smirnoff_plugins/collections/vsites.py
@@ -1,0 +1,107 @@
+from openff.interchange.smirnoff._virtual_sites import SMIRNOFFVirtualSiteCollection
+from openff.toolkit.typing.engines.smirnoff.parameters import (
+    VirtualSiteHandler,
+)
+
+from openff.interchange.components.potentials import Potential
+from openff.interchange.components.toolkit import _validated_list_to_array
+from openff.interchange.models import PotentialKey
+import abc
+from smirnoff_plugins.handlers.vsites import DoubleExponentialVsiteHandler
+
+
+class _VsitePlugin(SMIRNOFFVirtualSiteCollection, abc.ABC):
+    """
+    A general vsite plugin class used to make vsite collections compatible with a non-bonded collection
+    """
+
+    is_plugin = True
+    acts_as = "VirtualSites"
+
+    @classmethod
+    def supported_parameters(cls):
+        """Return a list of parameter attributes supported by this handler."""
+        return [
+            "type",
+            "name",
+            "id",
+            "match",
+            "smirks",
+            "charge_increment",
+            "distance",
+            "outOfPlaneAngle",
+            "inPlaneAngle",
+        ].extend(cls.specific_parameters())
+
+    @classmethod
+    @abc.abstractmethod
+    def specific_parameters(cls) -> list[str]: ...
+
+    @classmethod
+    @abc.abstractmethod
+    def allowed_parameter_handlers(cls):
+        """Return a list of allowed types of ParameterHandler classes."""
+        ...
+
+    def store_potentials(  # type: ignore[override]
+        self,
+        parameter_handler: VirtualSiteHandler,
+        vdw_handler,
+        electrostatics_handler,
+    ) -> None:
+        """Store VirtualSite-specific parameter-like data."""
+        if self.potentials:
+            self.potentials = dict()
+        for virtual_site_key, potential_key in self.key_map.items():
+            # TODO: This logic assumes no spaces in the SMIRKS pattern, name or `match` attribute
+            smirks, _, _ = potential_key.id.split(" ")
+            parameter = parameter_handler.parameters[smirks]
+
+            virtual_site_potential = Potential(
+                parameters={
+                    "distance": parameter.distance,
+                },
+            )
+            for attr in ["outOfPlaneAngle", "inPlaneAngle"]:
+                if hasattr(parameter, attr):
+                    virtual_site_potential.parameters.update(
+                        {attr: getattr(parameter, attr)},
+                    )
+            self.potentials[potential_key] = virtual_site_potential
+
+            vdw_key = PotentialKey(id=potential_key.id, associated_handler="vdw")
+            vdw_potential = Potential(
+                parameters=dict(
+                    (parameter_name, getattr(parameter, parameter_name))
+                    for parameter_name in self.specific_parameters()
+                )
+            )
+            vdw_handler.key_map[virtual_site_key] = vdw_key
+            vdw_handler.potentials[vdw_key] = vdw_potential
+
+            electrostatics_key = PotentialKey(
+                id=potential_key.id,
+                associated_handler="Electrostatics",
+            )
+            electrostatics_potential = Potential(
+                parameters={
+                    "charge_increments": _validated_list_to_array(
+                        parameter.charge_increment,
+                    ),
+                },
+            )
+            electrostatics_handler.key_map[virtual_site_key] = electrostatics_key
+            electrostatics_handler.potentials[electrostatics_key] = (
+                electrostatics_potential
+            )
+
+
+class SMIRNOFFDoubleExponentialVirtualSiteCollection(_VsitePlugin):
+
+    @classmethod
+    def allowed_parameter_handlers(cls):
+        return [DoubleExponentialVsiteHandler]
+
+    @classmethod
+    def specific_parameters(cls) -> list[str]:
+        return ["r_min", "epsilon"]

--- a/smirnoff_plugins/handlers/vsites.py
+++ b/smirnoff_plugins/handlers/vsites.py
@@ -1,0 +1,179 @@
+import numpy
+from openff.toolkit.typing.engines.smirnoff.parameters import (
+    IndexedParameterAttribute,
+    ParameterAttribute,
+    VirtualSiteHandler,
+    _VirtualSiteType,
+    ParameterType,
+    _validate_units,
+)
+from typing import Optional, get_args
+from openff.toolkit.utils.exceptions import SMIRNOFFSpecError
+from openff.units import unit
+
+
+class _BasicVirtualSiteType(ParameterType):
+    _ELEMENT_NAME = "VirtualSite"
+
+    name = ParameterAttribute(default="EP", converter=str)
+    type = ParameterAttribute(converter=str)
+
+    match = ParameterAttribute(converter=str)
+
+    distance = ParameterAttribute(unit=unit.angstrom)
+    outOfPlaneAngle = ParameterAttribute(unit=unit.degree)
+    inPlaneAngle = ParameterAttribute(unit=unit.degree)
+
+    charge_increment = IndexedParameterAttribute(unit=unit.elementary_charge)
+
+    @property
+    def parent_index(self) -> int:
+        """Returns the index of the atom matched by the SMIRKS pattern that should
+        be considered the 'parent' to the virtual site.
+        A value of ``0`` corresponds to the atom matched by the ``:1`` selector in
+        the SMIRKS pattern, a value ``2`` the atom matched by ``:2`` and so on.
+        """
+        return self.type_to_parent_index(self.type)
+
+    @classmethod
+    def type_to_parent_index(cls, type_: _VirtualSiteType) -> int:
+        """Returns the index of the atom matched by the SMIRKS pattern that should
+        be considered the 'parent' to a given type of virtual site.
+        A value of ``0`` corresponds to the atom matched by the ``:1`` selector in
+        the SMIRKS pattern, a value ``2`` the atom matched by ``:2`` and so on.
+        """
+
+        if type_.replace("VirtualSite", "") in get_args(_VirtualSiteType):
+            return 0
+
+        raise NotImplementedError()
+
+    @outOfPlaneAngle.converter  # type: ignore[no-redef]
+    def outOfPlaneAngle(self, attr, value):
+        if value == "None":
+            return
+
+        supports_out_of_plane_angle = self._supports_out_of_plane_angle(self.type)
+
+        if not supports_out_of_plane_angle and value is not None:
+            raise SMIRNOFFSpecError(
+                f"'{self.type}' sites do not support `outOfPlaneAngle`"
+            )
+        elif supports_out_of_plane_angle:
+            return _validate_units(attr, value, unit.degrees)
+
+        return value
+
+    @inPlaneAngle.converter  # type: ignore[no-redef]
+    def inPlaneAngle(self, attr, value):
+        if value == "None":
+            return
+
+        supports_in_plane_angle = self._supports_in_plane_angle(self.type)
+
+        if not supports_in_plane_angle and value is not None:
+            raise SMIRNOFFSpecError(
+                f"'{self.type}' sites do not support `inPlaneAngle`"
+            )
+        elif supports_in_plane_angle:
+            return _validate_units(attr, value, unit.degrees)
+
+        return value
+
+    def __init__(self, **kwargs):
+        self._add_default_init_kwargs(kwargs)
+        super().__init__(**kwargs)
+
+    @classmethod
+    def _add_default_init_kwargs(cls, kwargs):
+        """Adds any missing default values to the ``kwargs`` dictionary, and
+        partially validates any provided values that aren't easily validated with
+        converters.
+        """
+
+        type_ = kwargs.get("type", None)
+
+        if type_ is None:
+            raise SMIRNOFFSpecError("the `type` keyword is missing")
+        if type_ not in get_args(_VirtualSiteType):
+            raise SMIRNOFFSpecError(f"'{type_}' is not a supported virtual site type")
+
+        if "charge_increment" in kwargs:
+            expected_num_charge_increments = cls._expected_num_charge_increments(type_)
+            num_charge_increments = len(kwargs["charge_increment"])
+            if num_charge_increments != expected_num_charge_increments:
+                raise SMIRNOFFSpecError(
+                    f"'{type_}' virtual sites expect exactly {expected_num_charge_increments} "
+                    f"charge increments, but got {kwargs['charge_increment']} "
+                    f"(length {num_charge_increments}) instead."
+                )
+
+        supports_in_plane_angle = cls._supports_in_plane_angle(type_)
+        supports_out_of_plane_angle = cls._supports_out_of_plane_angle(type_)
+
+        if not supports_out_of_plane_angle:
+            kwargs["outOfPlaneAngle"] = kwargs.get("outOfPlaneAngle", None)
+        if not supports_in_plane_angle:
+            kwargs["inPlaneAngle"] = kwargs.get("inPlaneAngle", None)
+
+        match = kwargs.get("match", None)
+
+        if match is None:
+            raise SMIRNOFFSpecError("the `match` keyword is missing")
+
+        out_of_plane_angle = kwargs.get("outOfPlaneAngle", 0.0 * unit.degree)
+        is_in_plane = (
+            None
+            if not supports_out_of_plane_angle
+            else numpy.isclose(out_of_plane_angle.m_as(unit.degree), 0.0)
+        )
+
+        if not cls._supports_match(type_, match, is_in_plane):
+            raise SMIRNOFFSpecError(
+                f"match='{match}' not supported with type='{type_}'"
+                + ("" if is_in_plane is None else f" and is_in_plane={is_in_plane}")
+            )
+
+    @classmethod
+    def _supports_in_plane_angle(cls, type_: _VirtualSiteType) -> bool:
+        return type_ in {"MonovalentLonePair"}
+
+    @classmethod
+    def _supports_out_of_plane_angle(cls, type_: _VirtualSiteType) -> bool:
+        return type_ in {"MonovalentLonePair", "DivalentLonePair"}
+
+    @classmethod
+    def _expected_num_charge_increments(cls, type_: _VirtualSiteType) -> int:
+        if type_ == "BondCharge":
+            return 2
+        elif (type_ == "MonovalentLonePair") or (type_ == "DivalentLonePair"):
+            return 3
+        elif type_ == "TrivalentLonePair":
+            return 4
+        raise NotImplementedError()
+
+    @classmethod
+    def _supports_match(
+        cls, type_: _VirtualSiteType, match: str, is_in_plane: Optional[bool] = None
+    ) -> bool:
+        is_in_plane = True if is_in_plane is None else is_in_plane
+
+        if match == "once":
+            return type_ == "TrivalentLonePair" or (
+                type_ == "DivalentLonePair" and is_in_plane
+            )
+        elif match == "all_permutations":
+            return type_ in {"BondCharge", "MonovalentLonePair", "DivalentLonePair"}
+
+        raise NotImplementedError()
+
+
+class DoubleExponentialVirtualSiteHandler(VirtualSiteHandler):
+    """Vsite handler compatible with the Double Exponential handler"""
+
+    class DoubleExponentialVirtualSiteType(_BasicVirtualSiteType):
+        r_min = ParameterAttribute(default=None, unit=unit.nanometers)
+        epsilon = ParameterAttribute(default=None, unit=unit.kilojoule_per_mole)
+
+    _TAGNAME = "DoubleExponentialVirtualSites"
+    _INFOTYPE = DoubleExponentialVirtualSiteType


### PR DESCRIPTION
## Description
This PR adds a template to make it easy to add virtual site handlers and collections for plugin non-bonded potentials. An example compatible with double exponential is also added.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] test the energies for a molecule with a dexp non-zero vsite.

## Questions
- [ ] Question1

## Status
- [ ] Ready to go