### PR TITLE
Remove spaces from the Urey-Bradley energy expression

### DIFF
--- a/smirnoff_plugins/collections/valence.py
+++ b/smirnoff_plugins/collections/valence.py
@@ -32,7 +32,7 @@ class SMIRNOFFUreyBradleyCollection(SMIRNOFFCollection):
 
     type: Literal["UreyBradleys"] = "UreyBradleys"
 
-    expression: Literal["k/2*(r - length)**2"] = "k/2*(r - length)**2"
+    expression: Literal["k/2*(r-length)**2"] = "k/2*(r-length)**2"
 
     @classmethod
     def allowed_parameter_handlers(cls) -> Iterable[Type[ParameterHandler]]:


### PR DESCRIPTION
Apologies for missing this during the original PR.

This removes spaces from the Urey-Bradley energy expression, making it identical to the bond force expression. This makes it slightly easier to hijack the functionality for training bonds in SMEE.

Thanks.