### PR TITLE
Fix handling of DoubleExponentialVirtualSites

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -9,7 +9,7 @@ dependencies:
   - numpy
   - openmm
   - openff-toolkit >=0.17
-  - openff-interchange ~=0.4.0
+  - openff-interchange ~=0.4.6
   - openff-utilities
   - rdkit
 
@@ -20,7 +20,3 @@ dependencies:
   - pytest-randomly
 
   - mypy
-
-  # Temporary workaround (until new realease) to install latest interchange with double exponential virtual sites issue fixed
-  - pip: 
-    - git+https://github.com/openforcefield/openff-interchange.git@main

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -8,7 +8,7 @@ dependencies:
     # Core dependencies
   - numpy
   - openmm
-  - openff-toolkit =0.16
+  - openff-toolkit >=0.17
   - openff-interchange ~=0.4.0
   - openff-utilities
   - rdkit
@@ -20,3 +20,7 @@ dependencies:
   - pytest-randomly
 
   - mypy
+
+  # Temporary workaround to get install interchange branch which fixes the double exponential virtual sites issue
+  - pip: 
+    - git+https://github.com/openforcefield/openff-interchange.git@bugfix-double-exponential-virtual-sites

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -21,6 +21,6 @@ dependencies:
 
   - mypy
 
-  # Temporary workaround to get install interchange branch which fixes the double exponential virtual sites issue
+  # Temporary workaround (until new realease) to install latest interchange with double exponential virtual sites issue fixed
   - pip: 
-    - git+https://github.com/openforcefield/openff-interchange.git@bugfix-double-exponential-virtual-sites
+    - git+https://github.com/openforcefield/openff-interchange.git@main

--- a/smirnoff_plugins/_tests/handlers/test_nonbonded.py
+++ b/smirnoff_plugins/_tests/handlers/test_nonbonded.py
@@ -953,7 +953,6 @@ def test_multipole_de6810_axilrod_options():
     assert from_openmm(omm_state.getPotentialEnergy()).m == pytest.approx(0.0)
 
 
-@pytest.mark.skip(reason="Fix me!")
 def test_non_lj_on_virtual_site(ideal_water_force_field):
     """
     Test virtual sites with non-12-6 interactions.

--- a/smirnoff_plugins/collections/vsites.py
+++ b/smirnoff_plugins/collections/vsites.py
@@ -11,6 +11,7 @@ from openff.interchange.smirnoff._virtual_sites import (
 )
 from openff.toolkit.typing.engines.smirnoff.parameters import VirtualSiteHandler
 
+from smirnoff_plugins.handlers.nonbonded import DoubleExponentialHandler
 from smirnoff_plugins.handlers.vsites import DoubleExponentialVirtualSiteHandler
 
 
@@ -47,6 +48,12 @@ class _VsitePlugin(SMIRNOFFVirtualSiteCollection, abc.ABC):
     @abc.abstractmethod
     def allowed_parameter_handlers(cls):
         """Return a list of allowed types of ParameterHandler classes."""
+        ...
+
+    @classmethod
+    @abc.abstractmethod
+    def allowed_vdw_parameter_handlers(cls):
+        """Return a list of allowed types of vdW ParameterHandler classes."""
         ...
 
     def store_potentials(  # type: ignore[override]
@@ -142,6 +149,10 @@ class SMIRNOFFDoubleExponentialVirtualSiteCollection(_VsitePlugin):
     @classmethod
     def allowed_parameter_handlers(cls):
         return [DoubleExponentialVirtualSiteHandler]
+
+    @classmethod
+    def allowed_vdw_parameter_handlers(cls):
+        return [DoubleExponentialHandler]
 
     @classmethod
     def specific_parameters(cls) -> list[str]:


### PR DESCRIPTION
This partially addresses
https://github.com/openforcefield/openff-interchange/issues/1310.

## Description

Please see the description/ discussion in https://github.com/openforcefield/openff-interchange/pull/1312.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Add allowed_vdw_parameter_handlers class method to _VsitePlugin

## Status
- [x] Ready to go