### PR TITLE
Add proper torsion-bend coupling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
     # Make the handler plugins discoverable.
     entry_points={
         "openff.toolkit.plugins.handlers": [
+            "ProperTorsionBendHandler = smirnoff_plugins.handlers.valence:ProperTorsionBendHandler",
             "UreyBradleyHandler = smirnoff_plugins.handlers.valence:UreyBradleyHandler",
             "DampedBuckingham68Handler = smirnoff_plugins.handlers.nonbonded:DampedBuckingham68Handler",
             "DoubleExponentialHandler = smirnoff_plugins.handlers.nonbonded:DoubleExponentialHandler",
@@ -48,6 +49,7 @@ setup(
             "DoubleExponentialVirtualSiteHandler = smirnoff_plugins.handlers.vsites:DoubleExponentialVirtualSiteHandler",
         ],
         "openff.interchange.plugins.collections": [
+            "SMIRNOFFProperTorsionBendCollection = smirnoff_plugins.collections.valence:SMIRNOFFProperTorsionBendCollection",
             "SMIRNOFFUreyBradleyCollection = smirnoff_plugins.collections.valence:SMIRNOFFUreyBradleyCollection",
             "SMIRNOFFDampedBuckingham68Collection = smirnoff_plugins.collections.nonbonded:SMIRNOFFDampedBuckingham68Collection",
             "DoubleExponentialCollection = smirnoff_plugins.collections.nonbonded:SMIRNOFFDoubleExponentialCollection",

--- a/smirnoff_plugins/_tests/handlers/test_valence.py
+++ b/smirnoff_plugins/_tests/handlers/test_valence.py
@@ -7,7 +7,10 @@ from openff.interchange import Interchange
 from openff.interchange.drivers.openmm import _get_openmm_energies
 from openff.toolkit import ForceField, Molecule, Topology, unit
 
-from smirnoff_plugins.collections.valence import SMIRNOFFUreyBradleyCollection
+from smirnoff_plugins.collections.valence import (
+    SMIRNOFFProperTorsionBendCollection,
+    SMIRNOFFUreyBradleyCollection,
+)
 
 
 @pytest.fixture(scope="module")
@@ -25,6 +28,120 @@ def methane_molecule():
     methane = Molecule.from_mapped_smiles("[C:1]([H:2])([H:3])([H:4])([H:5])")
     methane.add_conformer(POSITIONS)
     return methane
+
+
+@pytest.fixture(scope="module")
+def peroxide_molecule_info():
+    """Fixture to create a hydrogen peroxide molecule with a fixed set of positions
+    and to supply geometry and expected energy information."""
+
+    POSITIONS = [
+        [-1.29431103, -0.18475285, -0.15111464],
+        [-0.56095895, 0.40009688, 0.13385895],
+        [0.52896993, -0.33976786, 0.17983297],
+        [1.32630004, 0.12442383, -0.16257729],
+    ] * unit.angstrom
+
+    # Calculated from the coordinates
+    ANGLE0 = 120.0 * openmm.unit.degree
+    ANGLES = [
+        1.8690299459800725 * openmm.unit.radian,
+        1.9747422196821367 * openmm.unit.radian,
+    ]
+
+    DIHEDRAL_ANGLE = 2.439148499977821 * openmm.unit.radian
+    KS = [
+        10.0 * openmm.unit.kilocalorie_per_mole,
+        5.0 * openmm.unit.kilocalorie_per_mole,
+    ]
+
+    peroxide = Molecule.from_mapped_smiles("[H:1][O:2][O:3][H:4]")
+    peroxide.add_conformer(POSITIONS)
+
+    # Get the expected proper torsion-bend energy
+    expected_ptb_energy = 0.0 * openmm.unit.kilocalorie_per_mole
+    for angle in ANGLES:
+        for n, k in enumerate(KS, start=1):
+            phase = (
+                0.0 * openmm.unit.radian
+                if n == 1
+                else openmm.math.pi * openmm.unit.radian
+            )
+            expected_ptb_energy += (
+                k
+                * (angle - ANGLE0)
+                / openmm.unit.radian
+                * (
+                    1
+                    + openmm.math.cos((n * DIHEDRAL_ANGLE - phase) / openmm.unit.radian)
+                )
+            )
+
+    return {
+        "molecule": peroxide,
+        "expected_ptb_energy": expected_ptb_energy,
+    }
+
+
+@pytest.fixture(scope="module")
+def proper_torsion_bend_force_field():
+    ff = ForceField("openff_unconstrained-2.2.1.offxml", load_plugins=True)
+    proper_torsion_bend_handler = ff.get_parameter_handler("ProperTorsionBends")
+    # Parameters for chloroethyne
+    proper_torsion_bend_handler.add_parameter(
+        {
+            "smirks": "[*:1]-[*:2]#[*:3]-[*:4]",
+            "angle0": 180.0 * unit.degree,
+            "k1": 10.0 * unit.kilocalorie / unit.mole,
+            "periodicity1": 1,
+            "phase1": 0.0 * unit.degree,
+            "k2": 5.0 * unit.kilocalorie / unit.mole,
+            "periodicity2": 2,
+            "phase2": 180.0 * unit.degree,
+        }
+    )
+    proper_torsion_bend_handler.add_parameter(
+        {
+            "smirks": "[Cl:1]-[*:2]#[*:3]-[*:4]",
+            "angle0": 180.0 * unit.degree,
+            "k1": 10.0 * unit.kilocalorie / unit.mole,
+            "periodicity1": 1,
+            "phase1": 0.0 * unit.degree,
+        },
+    )
+    # Parameters for methanol
+    proper_torsion_bend_handler.add_parameter(
+        {
+            "smirks": "[H:1]-[C:2]-[O:3]-[H:4]",
+            "angle0": 180.0 * unit.degree,
+            "k1": 10.0 * unit.kilocalorie / unit.mole,
+            "periodicity1": 1,
+            "phase1": 0.0 * unit.degree,
+        },
+    )
+    proper_torsion_bend_handler.add_parameter(
+        {
+            "smirks": "[H:1]-[O:2]-[C:3]-[H:4]",
+            "angle0": 180.0 * unit.degree,
+            "k1": 10.0 * unit.kilocalorie / unit.mole,
+            "periodicity1": 1,
+            "phase1": 0.0 * unit.degree,
+        },
+    )
+    # Parameters for peroxide
+    proper_torsion_bend_handler.add_parameter(
+        {
+            "smirks": "[H:1]-[O:2]-[O:3]-[H:4]",
+            "angle0": 120.0 * unit.degree,
+            "k1": 10.0 * unit.kilocalorie / unit.mole,
+            "periodicity1": 1,
+            "phase1": 0.0 * unit.degree,
+            "k2": 5.0 * unit.kilocalorie / unit.mole,
+            "periodicity2": 2,
+            "phase2": 180.0 * unit.degree,
+        },
+    )
+    return ff
 
 
 @pytest.mark.parametrize(
@@ -170,3 +287,112 @@ def test_urey_bradley_incorrect_smirks(methane_molecule: Molecule):
         ValueError, match="Expected 2 indices for Urey-Bradley potential"
     ):
         interchange.to_openmm()
+
+
+@pytest.mark.parametrize(
+    "mapped_smiles,expected_smirks_by_indices",
+    [
+        # Chloroethyne
+        (
+            "[Cl:1]-[C:2]#[C:3]-[H:4]",
+            {
+                (0, 1, 2, 3): "[Cl:1]-[*:2]#[*:3]-[*:4]",
+                (3, 2, 1, 0): "[*:1]-[*:2]#[*:3]-[*:4]",
+            },
+        ),
+        # Methanol
+        (
+            "[H:1][O:2][C:3]([H:4])([H:5])[H:6]",
+            {
+                (0, 1, 2, 3): "[H:1]-[O:2]-[C:3]-[H:4]",
+                (0, 1, 2, 4): "[H:1]-[O:2]-[C:3]-[H:4]",
+                (0, 1, 2, 5): "[H:1]-[O:2]-[C:3]-[H:4]",
+                (3, 2, 1, 0): "[H:1]-[C:2]-[O:3]-[H:4]",
+                (4, 2, 1, 0): "[H:1]-[C:2]-[O:3]-[H:4]",
+                (5, 2, 1, 0): "[H:1]-[C:2]-[O:3]-[H:4]",
+            },
+        ),
+    ],
+)
+def test_proper_torsion_bend_assignment(
+    mapped_smiles: str,
+    expected_smirks_by_indices: dict[tuple[int, int, int, int], str],
+    proper_torsion_bend_force_field: ForceField,
+):
+    """Check that the ProperTorsionBend terms are assigned correctly."""
+    topology = Molecule.from_mapped_smiles(mapped_smiles).to_topology()
+    interchange = Interchange.from_smirnoff(
+        force_field=proper_torsion_bend_force_field, topology=topology
+    )
+
+    collection = cast(
+        SMIRNOFFProperTorsionBendCollection,
+        interchange.collections["ProperTorsionBends"],
+    )
+
+    expected_indices = set(expected_smirks_by_indices.keys())
+    assigned_indices = set(key.atom_indices for key in collection.key_map.keys())
+    assert assigned_indices == expected_indices
+
+    # TODO: Figure out why the index types are not inferred correctly here.
+    for key, param in collection.key_map.items():
+        expected_smirks = expected_smirks_by_indices[key.atom_indices]  # type: ignore[index]
+        assert param.id == expected_smirks, (
+            f"For atom indices {key.atom_indices}, expected SMIRKS {expected_smirks}, "
+            f"but got {param.id}."
+        )
+
+
+def test_proper_torsion_bend_energy(
+    peroxide_molecule_info: dict[str, Molecule | openmm.unit.Quantity],
+    proper_torsion_bend_force_field: ForceField,
+):
+    """Check that the ProperTorsionBend energy is as expected for peroxide."""
+    topology = peroxide_molecule_info["molecule"].to_topology()
+    interchange = Interchange.from_smirnoff(
+        force_field=proper_torsion_bend_force_field, topology=topology
+    )
+
+    omm_system = interchange.to_openmm()
+    positions = interchange.positions
+    assert positions is not None  # Keep mypy happy
+
+    raw_energies = _get_openmm_energies(
+        system=omm_system,
+        box_vectors=None,
+        positions=positions.to_openmm(),
+        round_positions=None,
+        platform="Reference",
+    )
+
+    forces = omm_system.getForces()
+    ptb_forces = [
+        force for force in forces if force.getName() == "ProperTorsionBendForce"
+    ]
+
+    assert (
+        len(ptb_forces) == 1
+    ), "Expected exactly one ProperTorsionBend force in the OpenMM system."
+
+    ptb_force = ptb_forces[0]
+    num_ptb_terms = ptb_force.getNumBonds()
+    ptb_force_idx = forces.index(ptb_force)
+    ptb_energy = raw_energies[ptb_force_idx]
+
+    # Expect 4 terms, as we have two H-O-O-H torsion-bends (one for each angle in the
+    # torsion), each with two periodicities.
+    assert (
+        num_ptb_terms == 4
+    ), f"Expected 4 ProperTorsionBend terms, but got {num_ptb_terms}."
+
+    # Calculate expected energy:
+
+    ptb_energy /= openmm.unit.kilocalorie_per_mole
+    expected_ptb_energy = (
+        peroxide_molecule_info["expected_ptb_energy"] / openmm.unit.kilocalorie_per_mole
+    )
+
+    assert pytest.approx(expected_ptb_energy, rel=1e-5) == ptb_energy, (
+        f"Expected ProperTorsionBend energy to be {expected_ptb_energy} kJ/mol, "
+        f"but got {ptb_energy} kJ/mol."
+    )

--- a/smirnoff_plugins/collections/valence.py
+++ b/smirnoff_plugins/collections/valence.py
@@ -1,17 +1,22 @@
 from functools import lru_cache
-from typing import Dict, Iterable, Literal, Set, Tuple, Type, Union
+from typing import Dict, Iterable, Literal, Set, Tuple, Type, Union, cast
 
 from openff.interchange import Interchange
 from openff.interchange.components.potentials import Potential
+from openff.interchange.components.toolkit import _PERIODICITIES
 from openff.interchange.interop.openmm._valence import _is_constrained
-from openff.interchange.models import PotentialKey, VirtualSiteKey
+from openff.interchange.models import PotentialKey, TopologyKey, VirtualSiteKey
 from openff.interchange.smirnoff._base import SMIRNOFFCollection
-from openff.toolkit import Quantity
+from openff.toolkit import Quantity, Topology
 from openff.toolkit import unit as off_unit
 from openff.toolkit.typing.engines.smirnoff.parameters import ParameterHandler
 from openmm import openmm
+from pydantic import Field
 
-from smirnoff_plugins.handlers.valence import UreyBradleyHandler
+from smirnoff_plugins.handlers.valence import (
+    ProperTorsionBendHandler,
+    UreyBradleyHandler,
+)
 
 
 @lru_cache
@@ -25,6 +30,88 @@ def _cache_urey_bradley_parameter_lookup(
         parameter_name: getattr(parameter, parameter_name)
         for parameter_name in ["k", "length"]
     }
+
+
+@lru_cache
+def _cache_proper_torsion_bend_parameter_lookup(
+    potential_key: PotentialKey,
+    parameter_handler: ParameterHandler,
+) -> dict[str, Quantity]:
+    smirks = potential_key.id
+    n = potential_key.mult
+    parameter = parameter_handler.parameters[smirks]
+
+    return {
+        "angle0": parameter.angle0,
+        "k": parameter.k[n],
+        "periodicity": _PERIODICITIES[parameter.periodicity[n]],
+        "phase": parameter.phase[n],
+    }
+
+
+class ProperTorsionBendKey(TopologyKey):
+    """
+    A unique identifier of the atoms associated in a proper torsion bend potential.
+
+    Examples
+    --------
+    Index into a dictionary with a tuple
+
+    .. code-block:: pycon
+
+        >>> d = {
+        ...     ProperTorsionKey(atom_indices=(0, 1, 2, 3)): "torsion1",
+        ...     ProperTorsionKey(atom_indices=(0, 1, 2, 3), mult=2): "torsion2",
+        ... }
+        >>> d[0, 1, 2, 3]
+        'torsion1'
+        >>> d[(0, 1, 2, 3), 2, None, None]
+        'torsion2'
+    """
+
+    atom_indices: tuple[int, int, int, int] = Field(
+        description="The indices of the atoms occupied by this interaction",
+    )
+
+    mult: int | None = Field(
+        None,
+        description="The index of this duplicate interaction",
+    )
+
+    phase: float | None = Field(
+        None,
+        description="If this key represents as topology component subject to interpolation between "
+        "multiple parameters(s), the phase determining the coefficients of the wrapped "
+        "potentials.",
+    )
+
+    def _tuple(
+        self,
+    ) -> (
+        tuple[int, int, int, int]
+        | tuple[
+            tuple[int, int, int, int],
+            int | None,
+            float | None,
+        ]
+    ):
+        if self.mult is None and self.phase is None:
+            return cast(tuple[int, int, int, int], self.atom_indices)
+        else:
+            return (
+                cast(
+                    tuple[int, int, int, int],
+                    self.atom_indices,
+                ),
+                self.mult,
+                self.phase,
+            )
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__} with atom indices {self.atom_indices}"
+            f"{'' if self.mult is None else ', mult ' + str(self.mult)}"
+        )
 
 
 class SMIRNOFFUreyBradleyCollection(SMIRNOFFCollection):
@@ -113,4 +200,131 @@ class SMIRNOFFUreyBradleyCollection(SMIRNOFFCollection):
                 particle2=openmm_indices[1],
                 length=length,
                 k=k,
+            )
+
+
+class SMIRNOFFProperTorsionBendCollection(SMIRNOFFCollection):
+    """Handler storing proper torsion-bend potentials."""
+
+    is_plugin: bool = True
+
+    type: Literal["ProperTorsionBends"] = "ProperTorsionBends"
+    expression: Literal[
+        "k*(angle(p1,p2,p3)-angle0)*(1+cos(periodicity*dihedral(p1,p2,p3,p4)-phase))"
+    ] = "k*(angle(p1,p2,p3)-angle0)*(1+cos(periodicity*dihedral(p1,p2,p3,p4)-phase))"
+
+    @classmethod
+    def allowed_parameter_handlers(cls):
+        """Return a list of allowed types of ParameterHandler classes."""
+        return [ProperTorsionBendHandler]
+
+    @classmethod
+    def supported_parameters(cls):
+        """Return a list of supported parameter attribute names."""
+        return ["smirks", "id", "angle0", "k", "periodicity", "phase"]
+
+    @classmethod
+    def potential_parameters(cls):
+        """Return a list of names of parameters included in each potential in this collection."""
+        return ["k", "angle0", "periodicity", "phase"]
+
+    def store_matches(
+        self,
+        parameter_handler: ProperTorsionBendHandler,
+        topology: Topology,
+    ) -> None:
+        """
+        Populate self.key_map with key-val pairs of keys and unique potential identifiers.
+
+        """
+        if self.key_map:
+            self.key_map: dict[ProperTorsionBendKey, PotentialKey] = dict()
+        matches = parameter_handler.find_matches(topology)
+        for key, val in matches.items():
+            parameter: ProperTorsionBendHandler.ProperTorsionBendType = (
+                val.parameter_type
+            )
+
+            n_terms = len(parameter.phase)
+
+            cosmetic_attributes = {
+                cosmetic_attribute: getattr(
+                    parameter,
+                    f"_{cosmetic_attribute}",
+                )
+                for cosmetic_attribute in parameter._cosmetic_attribs
+            }
+
+            for n in range(n_terms):
+                smirks = parameter.smirks
+
+                topology_key = ProperTorsionBendKey(
+                    atom_indices=key,
+                    mult=n,
+                )
+
+                potential_key = PotentialKey(
+                    id=smirks,
+                    mult=n,
+                    associated_handler="ProperTorsionBends",
+                    cosmetic_attributes=cosmetic_attributes,
+                )
+
+                self.key_map[topology_key] = potential_key
+
+    def store_potentials(self, parameter_handler: ProperTorsionBendHandler) -> None:
+        """Store the potentials from the parameter handler."""
+        for potential_key in self.key_map.values():
+            self.potentials.update(
+                {
+                    potential_key: Potential(
+                        parameters=_cache_proper_torsion_bend_parameter_lookup(
+                            potential_key,
+                            parameter_handler,
+                        ),
+                    ),
+                },
+            )
+
+    def modify_openmm_forces(
+        self,
+        interchange: Interchange,
+        system: openmm.System,
+        add_constrained_forces: bool,
+        constrained_pairs: Set[Tuple[int, ...]],
+        particle_map: Dict[int, int],
+    ) -> None:
+
+        proper_torsion_bend_force = openmm.CustomCompoundBondForce(4, self.expression)
+        for param_name in self.potential_parameters():
+            proper_torsion_bend_force.addPerBondParameter(param_name)
+
+        proper_torsion_bend_force.setName("ProperTorsionBendForce")
+        system.addForce(proper_torsion_bend_force)
+
+        proper_torsion_bend_handler = interchange["ProperTorsionBends"]
+
+        for top_key, pot_key in proper_torsion_bend_handler.key_map.items():
+            openff_indices = top_key.atom_indices
+            openmm_indices = tuple(particle_map[index] for index in openff_indices)
+
+            params = proper_torsion_bend_handler.potentials[pot_key].parameters
+
+            k = params["k"].m_as(off_unit.kilojoule / off_unit.mol)
+            angle0 = params["angle0"].m_as(off_unit.radian)
+            periodicity = int(params["periodicity"])
+            phase = params["phase"].m_as(off_unit.radian)
+            proper_torsion_bend_force.addBond(
+                (
+                    openmm_indices[0],
+                    openmm_indices[1],
+                    openmm_indices[2],
+                    openmm_indices[3],
+                ),
+                (
+                    k,
+                    angle0,
+                    periodicity,
+                    phase,
+                ),
             )

--- a/smirnoff_plugins/handlers/valence.py
+++ b/smirnoff_plugins/handlers/valence.py
@@ -1,10 +1,29 @@
 from openff.toolkit import unit
+from openff.toolkit.topology.topology import Topology, _TransformedDict
 from openff.toolkit.typing.engines.smirnoff.parameters import (
     ConstraintHandler,
+    IndexedParameterAttribute,
     ParameterAttribute,
     ParameterHandler,
     ParameterType,
 )
+
+
+class ProperTorsionBendDict(_TransformedDict):
+    """For ProperTorsionBend interactions, i,j,k,l <-> l,k,j,i symmetry is not preserved,
+    so avoid symmetrising keys as done in ValenceDict."""
+
+    def __repr__(self):
+        d = {k: v for k, v in self.items()}
+        return f"ProperTorsionBendDict({d!r})"
+
+    def _repr_pretty_(self, p, cycle):
+        if cycle:
+            p.text("ProperTorsionBendDict(...)")
+        else:
+            with p.group(2, "ProperTorsionBendDict(", ")"):
+                p.breakable("")
+                p.pretty({k: v for k, v in self.items()})
 
 
 class UreyBradleyHandler(ParameterHandler):
@@ -23,3 +42,53 @@ class UreyBradleyHandler(ParameterHandler):
     _TAGNAME = "UreyBradleys"
     _INFOTYPE = UreyBradleyType
     _DEPENDENCIES = [ConstraintHandler]
+
+
+class ProperTorsionBendHandler(ParameterHandler):
+    """
+    A custom SMIRNOFF handler for Proper Torsion-Bend coupling interactions.
+    The functional form is as given in eqn. 10 in Nevins, N.; Chen, K.;
+    Allinger, N. L. Molecular Mechanics (MM4) Calculations on Alkenes.
+    J. Comput. Chem. 1996, 17 (5–6), 669–694.
+    https://doi.org/10.1002/(SICI)1096-987X(199604)17:5/6%253C669::AID-JCC7%253E3.0.CO;2-S.
+    Each line in the OFFXML file specifies the term corresponding to a single bond angle-proper
+    torsion combination, hence two lines are needed to specify the whole of eqn. 10. The angle
+    is specified by the first 3 labels in the SMIRKS e.g. i,j,k in i,j,k,l. Hence, the order of
+    the labels in the SMIRKS matters, and i,j,k,l is not equivalent to l,k,j,i if the type is not
+    symmetrical.
+    """
+
+    class ProperTorsionBendType(ParameterType):
+        """
+        A custom SMIRNOFF type for Proper Torsion-Bend coupling interactions.
+
+        """
+
+        _ELEMENT_NAME = "ProperTorsionBend"
+
+        angle0 = ParameterAttribute(unit=unit.degree)
+        periodicity = IndexedParameterAttribute(converter=int)
+        phase = IndexedParameterAttribute(unit=unit.degree)
+        k = IndexedParameterAttribute(default=None, unit=unit.kilocalorie / unit.mole)
+
+    _TAGNAME = "ProperTorsionBends"  # SMIRNOFF tag name to process
+    _INFOTYPE = ProperTorsionBendType  # info type to store
+
+    def find_matches(self, entity: Topology, unique: bool = False):
+        """Find the improper torsions in the topology/molecule matched by a parameter type.
+
+        Parameters
+        ----------
+        entity
+            Topology to search.
+
+        Returns
+        ---------
+        matches
+            ``matches[atom_indices]`` is the ``ParameterType`` object
+            matching the 4-tuple of atom indices in ``entity``.
+
+        """
+        return self._find_matches(
+            entity, transformed_dict_cls=ProperTorsionBendDict, unique=unique
+        )


### PR DESCRIPTION
## Description
Add terms which couple proper torsions and bond angles. From the `ProperTorsionBendHandler` docstring:
```
    A custom SMIRNOFF handler for Proper Torsion-Bend coupling interactions.
    The functional form is as given in eqn. 10 in Nevins, N.; Chen, K.;
    Allinger, N. L. Molecular Mechanics (MM4) Calculations on Alkenes.
    J. Comput. Chem. 1996, 17 (5–6), 669–694.
    https://doi.org/10.1002/(SICI)1096-987X(199604)17:5/6%253C669::AID-JCC7%253E3.0.CO;2-S.
    Each line in the OFFXML file specifies the term corresponding to a single bond angle-proper
    torsion combination, hence two lines are needed to specify the whole of eqn. 10. The angle
    is specified by the first 3 labels in the SMIRKS e.g. i,j,k in i,j,k,l. Hence, the order of
    the labels in the SMIRKS matters, and i,j,k,l is not equivalent to l,k,j,i if the type is not
    symmetrical.
```

## Status
- [x] Ready to go